### PR TITLE
AX-23725: Cache codecov uploader by version and os

### DIFF
--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -45,6 +45,16 @@ parameters:
     default: "latest"
 
 steps:
+  - when:
+      name: "Restore Codecov Uploader from CircleCI Cache"
+      condition:
+        not:
+          equal: [<< parameters.version >>, "latest"]
+      steps:
+        - restore_cache:
+            name: "Restoring Codecov Uploader from Cache"
+            keys:
+              - "v1-codecov-uploader-<< parameters.version >>-{{ arch }}"
   - run:
       name: Download Codecov Uploader
       command: <<include(scripts/download.sh)>>
@@ -59,6 +69,15 @@ steps:
             command: <<include(scripts/validate.sh)>>
             environment:
               CODECOV_PUBLIC_PGP_KEY: <<include(scripts/pgp_keys.asc)>>
+  - when:
+      condition:
+        not:
+          equal: [<< parameters.version >>, "latest"]
+      steps:
+        - save_cache:
+            name: Caching Codecov Uploader
+            key: "v1-codecov-uploader-<< parameters.version >>-{{ arch }}"
+            paths: "downloads"
   - run:
       name: Upload Coverage Results
       command: <<include(scripts/upload.sh)>>

--- a/src/scripts/download.sh
+++ b/src/scripts/download.sh
@@ -18,5 +18,10 @@ echo "export filename=${filename}" >> $BASH_ENV
 codecov_url="https://uploader.codecov.io"
 codecov_url="$codecov_url/${PARAM_VERSION}"
 codecov_url="$codecov_url/${os}/${filename}"
-echo "Downloading ${codecov_url}"
-curl -Os $codecov_url -v
+executable_path="downloads/${os}/${filename}"
+[[ $version != "latest" && -f "${executable_path}" ]] && \
+  echo "Using cached executable at ${executable_path}" || ( \
+    echo "Downloading ${codecov_url} to ${executable_path}" && \
+    curl $codecov_url -o "${executable_path}" -s -v --create-dirs
+  )
+cp "$executable_path" .


### PR DESCRIPTION
When a `version` parameter is specified, attempt to use a previously cached executable instead of downloading it again.